### PR TITLE
fix(ping.go): prevent nil addr and ensure blocking read behavior

### DIFF
--- a/pkg/probe/ping.go
+++ b/pkg/probe/ping.go
@@ -166,7 +166,7 @@ func (p *Ping) probeOne(id, seq uint16, conn net.PacketConn) (time.Duration, boo
 	}
 
 	for {
-		_, peer, err := conn.ReadFrom(nil)
+		_, peer, err := conn.ReadFrom(make([]byte, 1))
 		if err != nil && errors.Is(err, os.ErrDeadlineExceeded) {
 			return 0, true, nil
 		}


### PR DESCRIPTION
When a nil buffer is passed as the parameter `p`, testing on macOS shows that the call returns immediately without blocking, even if no packet is received. In these cases, both the error (`err`) and address (`addr`) return values are nil.